### PR TITLE
MemberDemote: fix panic

### DIFF
--- a/yokeadm/commands/memberDemote.go
+++ b/yokeadm/commands/memberDemote.go
@@ -30,6 +30,7 @@ func memberDemote(ccmd *cobra.Command, args []string) {
 	client, err := rpc.Dial("tcp", fmt.Sprintf("%s:%s", fHost, fPort))
 	if err != nil {
 		fmt.Printf("[commands/memberDemote] rpc.Dial() failed - %s\n", err.Error())
+		return
 	}
 	defer client.Close()
 


### PR DESCRIPTION
In the ```memberDemote``` method, If construction of RPC client is failed, should be return on this stage. 