### PR TITLE
import os

### DIFF
--- a/monitor/decision.go
+++ b/monitor/decision.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 	"errors"
+	"os"
 
 	"github.com/nanopack/yoke/state"
 	"github.com/nanopack/yoke/config"


### PR DESCRIPTION
 ``` import os``` is missing for call ```os.Exit(1)````