### PR TITLE
Fix scribble usage

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	config.ConfigurePGConf("0.0.0.0", config.Conf.PGPort)
 
-	store, err := scribble.New(config.Conf.StatusDir, config.Log)
+	store, err := scribble.New(config.Conf.StatusDir, &scribble.Options{Logger: config.Log})
 	if err != nil {
 		config.Log.Fatal("Scribble did not setup correctly - ", err.Error())
 		os.Exit(1)


### PR DESCRIPTION
https://github.com/nanobox-io/golang-scribble/commit/94c595be43a6d914444a6b9af32df467a4825774
has introduced a breaking change to golang-scribble API.
Use the new API to fix the build.